### PR TITLE
Remove gist.github.com.

### DIFF
--- a/SwitchyRules.ssrl
+++ b/SwitchyRules.ssrl
@@ -59,7 +59,6 @@
 *://*.twimg.com
 *://*.dwnews.net
 *://*.gravatar.com
-*://gist.github.com
 *://t.co
 
 [regexp]


### PR DESCRIPTION
This can be accessed via modifying /etc/hosts.
